### PR TITLE
Swap to stdin to make exclude patterns available

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+## 1.1.3
+- Reworked input from file to stdin to allow exclude-patterns to work.
 ## 1.1.2
 - Add note to readme about the publisher getting deleted.
 ## 1.1.1

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-phpcbf",
     "displayName": "phpcbf",
     "description": "PHP Code Beautifier & Fixer for Visual StudioCode",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "icon": "phpcbf.png",
     "publisher": "ValeryanM",
     "homepage": "https://github.com/valeryan/vscode-phpcbf",

--- a/src/resolvers/path-resolver-base.ts
+++ b/src/resolvers/path-resolver-base.ts
@@ -6,11 +6,11 @@
 
 export abstract class PhpcbfPathResolverBase {
 	protected phpcbfExecutableFile: string;
-	protected pathSeperator: string;
+	protected pathSeparator: string;
 
 	constructor() {
 		let extension = /^win/.test(process.platform) ? ".bat" : "";
-		this.pathSeperator = /^win/.test(process.platform) ? "\\" : "/";
+		this.pathSeparator = /^win/.test(process.platform) ? "\\" : "/";
 		this.phpcbfExecutableFile = `phpcbf${extension}`;
 	}
 

--- a/src/resolvers/standards-path-resolver.ts
+++ b/src/resolvers/standards-path-resolver.ts
@@ -17,16 +17,16 @@ export class StandardsPathResolver extends PhpcbfPathResolverBase {
         }
 
         let resolvedPath: string | null = null;
-        let workspaceRoot = this.config.workspaceRoot + this.pathSeperator;
+        let workspaceRoot = this.config.workspaceRoot + this.pathSeparator;
         let localPath = this.document.uri.fsPath.replace(workspaceRoot, '');
-        let paths = localPath.split(this.pathSeperator)
+        let paths = localPath.split(this.pathSeparator)
             .filter(path => path.includes('.php') !== true);
 
         let searchPaths = [];
 
         // create search paths based on file location
         for (let i = 0, len = paths.length; i < len; i++) {
-            searchPaths.push(workspaceRoot + paths.join(this.pathSeperator) + this.pathSeperator);
+            searchPaths.push(workspaceRoot + paths.join(this.pathSeparator) + this.pathSeparator);
             paths.pop();
         }
         searchPaths.push(workspaceRoot);


### PR DESCRIPTION
Writing to a temp file to prevent corrupting files if phpcbf has errors was not allowing exclude-patterns in the config to be applied. To alleviate this I am swapping to using the stdin approach. I am a little skeptical that this will not end up being flaky and broken but time will tell... This should address issue #8 but I will probably do more testing before releasing to the market place.